### PR TITLE
Pass existing buildArgs to argsOverride

### DIFF
--- a/packages/kernel/default.nix
+++ b/packages/kernel/default.nix
@@ -9,9 +9,7 @@
   kernelVersion = "5.10.110";
   vendorVersion = "";
   version = "${kernelVersion}${vendorVersion}";
-in
-  buildLinux (args
-    // {
+  buildArgs = {
       inherit version;
 
       # https://github.com/radxa/build/blob/428769f2ab689de27927af4bc8e7a9941677c366/board_configs.sh#L304
@@ -80,5 +78,8 @@ in
           ./0007-rock-5b-Configure-FIQ-debugger-as-115200.patch
           ./0008-rock-5b-disable-uart2-wont-bind-as-a-console.patch
         ];
-    }
-    // (args.argsOverride or {}))
+    };
+in
+  buildLinux (args
+    // buildArgs
+    // ((args.argsOverride or (_: {})) buildArgs))


### PR DESCRIPTION
Pass the custom kernel config and patches in `linux-rock5b` to a custom override function.  This can enable [use cases](https://github.com/KireinaHoro/flakes/blob/43f76d20c7a3f8b51df50d1294042f5360d4f719/nixos/iori/hardware.nix#L8-L39) where a downstream user can further customize the kernel.

This change is not backwards compatible for existing users of `argsOverride`, since now we expect a function instead of simply a attrset.  I don't have a good idea on how I can make this compatible...
