### PR TITLE
Kernel patches to improve quality

### DIFF
--- a/packages/kernel/0001-Ignore-implementation-defects-warned-by-newer-GCC.patch
+++ b/packages/kernel/0001-Ignore-implementation-defects-warned-by-newer-GCC.patch
@@ -29,25 +29,10 @@ index bcc1c1267d0c7c..a89a5339807372 100644
 @@ -1,6 +1,9 @@
  # SPDX-License-Identifier: GPL-2.0
  # Makefile for Linux PHY drivers
- 
+
 +# ¯\_(ツ)_/¯
 +CFLAGS_rk630phy.o += -Wno-error=incompatible-pointer-types
 +
  libphy-y			:= phy.o phy-c45.o phy-core.o phy_device.o \
  				   linkmode.o
  mdio-bus-y			+= mdio_bus.o mdio_device.o
-diff --git a/drivers/soc/rockchip/Makefile b/drivers/soc/rockchip/Makefile
-index 8f9439271fc383..07a92dbc90a844 100644
---- a/drivers/soc/rockchip/Makefile
-+++ b/drivers/soc/rockchip/Makefile
-@@ -2,6 +2,10 @@
- #
- # Rockchip Soc drivers
- #
-+
-+# ¯\_(ツ)_/¯
-+CFLAGS_iomux.o += -Wno-error=implicit-int
-+
- obj-$(CONFIG_ROCKCHIP_AMP) += rockchip_amp.o
- obj-$(CONFIG_ROCKCHIP_CPUINFO) += rockchip-cpuinfo.o
- obj-$(CONFIG_ROCKCHIP_GRF) += grf.o

--- a/packages/kernel/0009-Disable-CLOCK_ALLOW_WRITE_DEBUGFS.patch
+++ b/packages/kernel/0009-Disable-CLOCK_ALLOW_WRITE_DEBUGFS.patch
@@ -1,0 +1,22 @@
+From 6c29638292e3a425e4c4e1a45d2d44f8d78b42dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=2E=20Efe=20=C3=87etin?= <efectn@protonmail.com>
+Date: Mon, 13 Mar 2023 18:06:54 +0300
+Subject: [PATCH] Disable CLOCK_ALLOW_WRITE_DEBUGFS
+
+---
+ drivers/clk/clk.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/clk/clk.c b/drivers/clk/clk.c
+index bec8819414834..f5f3e9db05ad0 100644
+--- a/drivers/clk/clk.c
++++ b/drivers/clk/clk.c
+@@ -3107,7 +3107,7 @@ static int clk_dump_show(struct seq_file *s, void *data)
+ }
+ DEFINE_SHOW_ATTRIBUTE(clk_dump);
+ 
+-#define CLOCK_ALLOW_WRITE_DEBUGFS
++#undef CLOCK_ALLOW_WRITE_DEBUGFS
+ #ifdef CLOCK_ALLOW_WRITE_DEBUGFS
+ /*
+  * This can be dangerous, therefore don't provide any real compile time

--- a/packages/kernel/0010-fix-rockchip-iomux-init-include.patch
+++ b/packages/kernel/0010-fix-rockchip-iomux-init-include.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/soc/rockchip/iomux.c b/drivers/soc/rockchip/iomux.c
+index b6af2bd3b..7586f9d6f 100644
+--- a/drivers/soc/rockchip/iomux.c
++++ b/drivers/soc/rockchip/iomux.c
+@@ -9,6 +9,7 @@
+ #include <linux/fs.h>
+ #include <linux/list.h>
+ #include <linux/uaccess.h>
++#include <linux/init.h>
+ #include <linux/ioctl.h>
+ #include <linux/types.h>
+ #include <linux/miscdevice.h>

--- a/packages/kernel/default.nix
+++ b/packages/kernel/default.nix
@@ -77,6 +77,8 @@
         ./0006-arm64-boot-dts-rk3588-rock-5b-Enable-sfc-and-SPI-Flash.patch
         ./0007-rock-5b-Configure-FIQ-debugger-as-115200.patch
         ./0008-rock-5b-disable-uart2-wont-bind-as-a-console.patch
+        ./0009-Disable-CLOCK_ALLOW_WRITE_DEBUGFS.patch
+        ./0010-fix-rockchip-iomux-init-include.patch
       ];
   };
 in


### PR DESCRIPTION
As mentioned in https://github.com/aciceri/rock5b-nixos/issues/4, opening a pull request.  I also added a patch that [disables writable clock debugfs](https://github.com/MichaIng/DietPi/issues/6136), which seems to be a common issue in the Android kernels from Rockchip.